### PR TITLE
Implement API health check

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { checkSystem, Category } from "./api.js";
 
-// UI states you must handle for Issue 4: idle, loading, success, error.
+// Issue 2 establishes these UI states. Issue 4 will extend the success state
+// with the category list.
 type UiState = "idle" | "loading" | "success" | "error";
 
 export default function App() {
@@ -10,10 +11,16 @@ export default function App() {
   void categories;
 
   async function handleCheck() {
-    // TODO(Issue 4): set loading, call checkSystem(), then either
-    //   - success: store categories and show Online + the list, or
-    //   - error: show Offline + a useful message.
     setState("loading");
+
+    try {
+      const result = await checkSystem();
+      setCategories(result.categories);
+      setState("success");
+    } catch {
+      setCategories([]);
+      setState("error");
+    }
   }
 
   return (
@@ -23,10 +30,29 @@ export default function App() {
       </h1>
 
       <button className="btn btn-success" onClick={handleCheck} disabled={state === "loading"}>
-        {state === "loading" ? "Loading…" : "Check System"}
+        {state === "loading" ? "Loading..." : "Check System"}
       </button>
 
-      {/* TODO(Issue 4): render loading / success (Online + categories) / error (Offline) states. */}
+      {state === "loading" && (
+        <div className="alert alert-info mt-4" role="status">
+          Checking TokTickIT API...
+        </div>
+      )}
+
+      {state === "success" && (
+        <div className="alert alert-success mt-4" role="status">
+          <strong>System Status:</strong> Online
+        </div>
+      )}
+
+      {state === "error" && (
+        <div className="alert alert-danger mt-4" role="alert">
+          <p className="mb-1"><strong>System Status:</strong> Offline</p>
+          <p className="mb-0">Unable to connect to TokTickIT API</p>
+        </div>
+      )}
+
+      {/* TODO(Issue 4): render the categories returned by checkSystem(). */}
     </div>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -10,12 +10,26 @@ export interface SystemStatus {
   categories: Category[];
 }
 
-// Issue 2 + Issue 4 — call the backend.
-// Steps: fetch `${API_URL}/api/health`; if not ok, throw.
-//        then fetch `${API_URL}/api/categories`; if not ok, throw.
-//        return { online: true, categories }.
-// Throwing on failure lets the UI show a single Offline/error state.
+// Issue 2 checks the backend health endpoint. Issue 4 will extend the system
+// check with the categories request after the database work is available.
+interface HealthResponse {
+  status: string;
+  service: string;
+}
+
 export async function checkSystem(): Promise<SystemStatus> {
-  // TODO(Issue 2 & 4): implement the two fetch calls described above.
-  throw new Error("checkSystem not implemented yet");
+  const response = await fetch(`${API_URL}/api/health`);
+
+  if (!response.ok) {
+    throw new Error("TokTickIT API health check failed");
+  }
+
+  const health = (await response.json()) as HealthResponse;
+
+  if (health.status !== "ok" || health.service !== "TokTickIT API") {
+    throw new Error("TokTickIT API returned an unexpected health response");
+  }
+
+  // Issue 4 will extend this request with categories from PostgreSQL.
+  return { online: true, categories: [] };
 }

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -1,17 +1,43 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import App from "../../src/App.js";
+import * as api from "../../src/api.js";
 
 describe("App", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   // WORKED EXAMPLE — provided for you.
   it("renders the TokTickIT heading", () => {
     render(<App />);
     expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
   });
 
-  // Issue 4 — write these yourself. Hint: mock the api module with
-  // vi.spyOn(api, "checkSystem").mockResolvedValue(...) / .mockRejectedValue(...)
-  // then click the button and assert the Online list / Offline message.
+  it("shows Online when the health check succeeds", async () => {
+    vi.spyOn(api, "checkSystem").mockResolvedValue({ online: true, categories: [] });
+    const user = userEvent.setup();
+
+    render(<App />);
+    await user.click(screen.getByRole("button", { name: /check system/i }));
+
+    expect(await screen.findByText(/system status:/i)).toBeInTheDocument();
+    expect(screen.getByText("Online")).toBeInTheDocument();
+  });
+
+  it("shows an Offline error message when the API is unavailable", async () => {
+    vi.spyOn(api, "checkSystem").mockRejectedValue(new Error("Network error"));
+    const user = userEvent.setup();
+
+    render(<App />);
+    await user.click(screen.getByRole("button", { name: /check system/i }));
+
+    expect(await screen.findByText(/system status:/i)).toBeInTheDocument();
+    expect(screen.getByText("Offline")).toBeInTheDocument();
+    expect(screen.getByText(/unable to connect to TokTickIT API/i)).toBeInTheDocument();
+  });
+
+  // Issue 4 will verify that the seeded categories appear after success.
   it.todo("shows Online and the seeded categories on success");
-  it.todo("shows an Offline error message when the API is unavailable");
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -18,8 +18,7 @@ app.use(express.json());
 // It must return HTTP 200 with JSON: { status: "ok", service: "TokTickIT API" }
 // ---------------------------------------------------------------------------
 app.get("/api/health", (_req: Request, res: Response) => {
-  // TODO(Issue 2): replace this stub with the required 200 response.
-  res.status(501).json({ error: "Not implemented yet" });
+  res.status(200).json({ status: "ok", service: "TokTickIT API" });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- implement `GET /api/health` with the required HTTP 200 response
- call the health endpoint from the React client
- show loading, online, and offline states with useful feedback
- add client success/error tests while leaving the category test for Issue 4

## Why

Issue 2 proves that the React frontend can reach the Express backend through a real REST API call and can explain connection failures to the user.

## Stacked branch note

This draft PR is stacked on PR #5 (`feature/1-project-foundation`). Do not merge it until PR #5 has been peer-reviewed and merged into `lab1-staging`. GitHub should then recalculate this PR to show only the Issue 2 changes.

## Validation

- `server: npm run build` - passed
- `server: npm test -- --run` - health test passed; category test remains todo for Issue 4
- `client: npm run build` - passed
- `client: npm test -- --run` - 3 passed; category success test remains todo for Issue 4
- real HTTP check returned `200` and `{ "status": "ok", "service": "TokTickIT API" }`

Relates to #2.
