### PR TITLE
Display IT request category list

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,14 +1,11 @@
 import { useState } from "react";
 import { checkSystem, Category } from "./api.js";
 
-// Issue 2 establishes these UI states. Issue 4 will extend the success state
-// with the category list.
 type UiState = "idle" | "loading" | "success" | "error";
 
 export default function App() {
   const [state, setState] = useState<UiState>("idle");
   const [categories, setCategories] = useState<Category[]>([]);
-  void categories;
 
   async function handleCheck() {
     setState("loading");
@@ -40,9 +37,24 @@ export default function App() {
       )}
 
       {state === "success" && (
-        <div className="alert alert-success mt-4" role="status">
-          <strong>System Status:</strong> Online
-        </div>
+        <>
+          <div className="alert alert-success mt-4" role="status">
+            <strong>System Status:</strong> Online
+          </div>
+
+          <section aria-labelledby="category-heading">
+            <h2 id="category-heading" className="h5 mt-4">
+              IT Request Categories
+            </h2>
+            <ul className="list-group">
+              {categories.map((category) => (
+                <li className="list-group-item" key={category.id}>
+                  {category.name}
+                </li>
+              ))}
+            </ul>
+          </section>
+        </>
       )}
 
       {state === "error" && (
@@ -51,8 +63,6 @@ export default function App() {
           <p className="mb-0">Unable to connect to TokTickIT API</p>
         </div>
       )}
-
-      {/* TODO(Issue 4): render the categories returned by checkSystem(). */}
     </div>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -17,6 +17,13 @@ interface HealthResponse {
   service: string;
 }
 
+function isCategory(value: unknown): value is Category {
+  if (typeof value !== "object" || value === null) return false;
+
+  const category = value as Record<string, unknown>;
+  return typeof category.id === "number" && typeof category.name === "string";
+}
+
 export async function checkSystem(): Promise<SystemStatus> {
   const response = await fetch(`${API_URL}/api/health`);
 
@@ -30,6 +37,17 @@ export async function checkSystem(): Promise<SystemStatus> {
     throw new Error("TokTickIT API returned an unexpected health response");
   }
 
-  // Issue 4 will extend this request with categories from PostgreSQL.
-  return { online: true, categories: [] };
+  const categoriesResponse = await fetch(`${API_URL}/api/categories`);
+
+  if (!categoriesResponse.ok) {
+    throw new Error("TokTickIT API category request failed");
+  }
+
+  const categories = (await categoriesResponse.json()) as unknown;
+
+  if (!Array.isArray(categories) || !categories.every(isCategory)) {
+    throw new Error("TokTickIT API returned an unexpected category response");
+  }
+
+  return { online: true, categories };
 }

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -15,15 +15,15 @@ describe("App", () => {
     expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
   });
 
-  it("shows Online when the health check succeeds", async () => {
-    vi.spyOn(api, "checkSystem").mockResolvedValue({ online: true, categories: [] });
+  it("shows a loading state while checking the system", async () => {
+    vi.spyOn(api, "checkSystem").mockReturnValue(new Promise(() => undefined));
     const user = userEvent.setup();
 
     render(<App />);
     await user.click(screen.getByRole("button", { name: /check system/i }));
 
-    expect(await screen.findByText(/system status:/i)).toBeInTheDocument();
-    expect(screen.getByText("Online")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(/checking TokTickIT API/i);
+    expect(screen.getByRole("button", { name: /loading/i })).toBeDisabled();
   });
 
   it("shows an Offline error message when the API is unavailable", async () => {
@@ -38,6 +38,28 @@ describe("App", () => {
     expect(screen.getByText(/unable to connect to TokTickIT API/i)).toBeInTheDocument();
   });
 
-  // Issue 4 will verify that the seeded categories appear after success.
-  it.todo("shows Online and the seeded categories on success");
+  it("shows Online and the seeded categories on success", async () => {
+    vi.spyOn(api, "checkSystem").mockResolvedValue({
+      online: true,
+      categories: [
+        { id: 1, name: "Account and Access" },
+        { id: 2, name: "Hardware" },
+        { id: 3, name: "Software" },
+        { id: 4, name: "Network" },
+      ],
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+    await user.click(screen.getByRole("button", { name: /check system/i }));
+
+    expect(await screen.findByText("Online")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /IT request categories/i })).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem").map((item) => item.textContent)).toEqual([
+      "Account and Access",
+      "Hardware",
+      "Software",
+      "Network",
+    ]);
+  });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,9 +1,6 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
 import { getPrisma } from "./prisma.js";
-// getPrisma() is your lazy database handle. Call it INSIDE a route when you
-// need the DB (Issue 4). It is intentionally unused until then.
-void getPrisma;
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -21,13 +18,17 @@ app.get("/api/health", (_req: Request, res: Response) => {
   res.status(200).json({ status: "ok", service: "TokTickIT API" });
 });
 
-// ---------------------------------------------------------------------------
-// Issue 4 — Category list
-// Add:  GET /api/categories
-//   -> read categories from PostgreSQL via getPrisma().category.findMany(...)
-//   -> return each { id, name } in a predictable (id) order
-//   -> on failure, respond 500 with a safe message (no internal details)
-// TODO(Issue 4): implement the route here.
-// ---------------------------------------------------------------------------
+app.get("/api/categories", async (_req: Request, res: Response) => {
+  try {
+    const categories = await getPrisma().category.findMany({
+      select: { id: true, name: true },
+      orderBy: { id: "asc" },
+    });
+
+    res.status(200).json(categories);
+  } catch {
+    res.status(500).json({ error: "Unable to load IT request categories" });
+  }
+});
 
 export default app;

--- a/server/tests/lab-01/categories.test.ts
+++ b/server/tests/lab-01/categories.test.ts
@@ -1,15 +1,45 @@
-import { describe, it, expect } from "vitest";
+import { afterAll, afterEach, describe, it, expect, vi } from "vitest";
 import request from "supertest";
 import { app } from "../../src/app.js";
-void request; void app;
+import * as prismaModule from "../../src/prisma.js";
 
-// Issue 4 — write this test yourself, using health.test.ts as the pattern.
-// Requires the DB to be migrated and seeded first.
-// It should assert: GET /api/categories returns 200 and the four seeded
-// category names in id order.
-describe.todo("GET /api/categories", () => {
-  it.todo("returns the four seeded categories in id order", async () => {
-    // TODO(Issue 4): implement this assertion.
-    expect(true).toBe(true);
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterAll(async () => {
+  await prismaModule.getPrisma().$disconnect();
+});
+
+describe("GET /api/categories", () => {
+  it("returns the four seeded categories in id order", async () => {
+    const res = await request(app).get("/api/categories");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(4);
+    expect(res.body.map((category: { name: string }) => category.name)).toEqual([
+      "Account and Access",
+      "Hardware",
+      "Software",
+      "Network",
+    ]);
+    expect(res.body.every((category: { id: unknown }) => typeof category.id === "number")).toBe(true);
+    expect(res.body.map((category: { id: number }) => category.id)).toEqual(
+      [...res.body.map((category: { id: number }) => category.id)].sort((a, b) => a - b),
+    );
+  });
+
+  it("returns a safe error message when the database is unavailable", async () => {
+    vi.spyOn(prismaModule, "getPrisma").mockReturnValue({
+      category: {
+        findMany: vi.fn().mockRejectedValue(new Error("sensitive database details")),
+      },
+    } as unknown as ReturnType<typeof prismaModule.getPrisma>);
+
+    const res = await request(app).get("/api/categories");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Unable to load IT request categories" });
+    expect(JSON.stringify(res.body)).not.toContain("sensitive database details");
   });
 });


### PR DESCRIPTION
## Summary

- add `GET /api/categories` backed by Prisma and ordered by category ID;
- return only each category's `id` and `name`, with a safe 500 response on database failure;
- extend the client system check to fetch and validate the category response;
- render the categories returned by the API using accessible Bootstrap markup; and
- replace the remaining pending tests with loading, success, category-list, and database-error coverage.

## Why

This completes the Lab 1 full-stack vertical slice from React through Express and Prisma to PostgreSQL.

## Validation

- Prisma migration and seed apply successfully to a clean PostgreSQL 18 database.
- Direct HTTP checks return the expected health response and four categories in ID order.
- Server TypeScript build passes.
- Server Vitest/Supertest: 3 tests pass across health, category success, and safe database failure.
- Client production build passes.
- Client Vitest: 4 tests pass across heading, loading, offline error, and category-list success.
- The staged diff contains no `.env` file or credential.

Closes #4
