### PR TITLE
docs: finalize Lab 1 submission evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # TokTickIT
 
 TokTickIT is an IT service desk application developed for CPE334 Software
-Engineering in the Age of AI Agents. Lab 1 establishes a small full-stack
-vertical slice that connects a React user interface to an Express REST API and,
-in later Lab 1 issues, to PostgreSQL through Prisma.
+Engineering in the Age of AI Agents. Lab 1 delivers a small full-stack vertical
+slice that connects a React user interface to an Express REST API and a
+PostgreSQL database through Prisma.
 
 ## Lab 1 goal
 
-The completed Lab 1 application will let a user select **Check System** and see:
+The completed Lab 1 application lets a user select **Check System** and see:
 
 - whether the TokTickIT API is online;
 - the supported IT request categories stored in PostgreSQL;
@@ -96,8 +96,8 @@ commit either `.env` file.
 
 ## Database preparation
 
-The Category model, migration, and seed are implemented in Lab 1 Issue 3. Once
-that issue is available, run these commands from `server/`:
+The Category model, migration, and idempotent seed are included. Run these
+commands from `server/`:
 
 ```powershell
 npm run prisma:migrate -- --name init
@@ -138,13 +138,13 @@ npm run build
 npm test
 ```
 
-The starter scaffold intentionally contains failing or pending tests for later
-Lab 1 issues. Each feature issue must replace the relevant stub or pending test
-and make its acceptance tests pass.
+The final Lab 1 release contains seven passing automated tests: three server
+tests and four client tests. The commands above also verify both production
+builds.
 
 ## Lab 1 API contracts
 
-The following endpoints are delivered incrementally:
+The final Lab 1 release provides these endpoints:
 
 - `GET /api/health` - implemented in Issue 2
 - `GET /api/categories` - implemented in Issue 4 after the Issue 3 database work

--- a/docs/lab-01/ai_use.md
+++ b/docs/lab-01/ai_use.md
@@ -6,16 +6,19 @@ I used Codex as a pair-programming assistant for requirements analysis, Git work
 
 ## Selected key prompts
 
-| # | Prompt name | Prompt summary | How I used or corrected the result |
+The prompt text below is copied from my actual conversation with Codex. The
+original Thai wording is preserved rather than replaced with a summary.
+
+| # | Prompt name | Actual prompt text | How I used or corrected the result |
 |---|---|---|---|
-| 1 | Understand Lab 1 | Read the Labsheet and explain what must be done, why it is required, and the complete workflow for a beginner. | I used the explanation to understand the four dependent Issues and the required evidence before coding. |
-| 2 | Start Issue 1 | Open VS Code and guide me through creating the project foundation. | I followed the feature-branch workflow and checked that the React, Express, Prisma, and test scaffolds matched the required structure. |
-| 3 | Fix Issue 1 | Continue fixing Issue 1 and show where the work currently sits in the full flow. | The server TypeScript output path was corrected so the build output matched the start script before opening the PR. |
-| 4 | Use stacked branches | Begin the next Issues with a stacked-branch workflow and preserve the correct PR order. | I learned why parent PRs must merge first and allowed the branches to be resynchronized with `lab1-staging` after each merge. |
-| 5 | Troubleshoot PostgreSQL | Test PostgreSQL first because I was unsure of the password and it contained a special character. | The first credential approach failed. I did not share the password; instead, the tests were moved to an isolated PostgreSQL environment with a clean database. |
-| 6 | Implement Issue 3 | Continue the Category model, migration, and idempotent seed after the earlier PRs were merged. | I required the migration and seed to run twice and checked that there were exactly four distinct category names. |
-| 7 | Implement Issue 4 | Continue after peer review and build the category API, React list, loading state, error handling, and tests. | I checked that React rendered data returned by the API rather than hard-coded values and added safe database-error coverage. |
-| 8 | Final verification | After the final feature PR was approved and merged, verify everything again from a clean checkout. | The clean test exposed that Prisma Client had to be generated before seeding. I corrected the verification sequence, then reran builds, tests, and HTTP checks successfully. |
+| 1 | Understand Lab 1 | “เรียนรู้ lab นี้แล้วอธิบายให้ผมเข้าใจว่าต้องทำอะไรบ้าง ยังไง ขั้นตอนไหนบ้าง อย่างละเอียด” | I used the explanation to understand the four dependent Issues, the reason for each step, and the required evidence before coding. |
+| 2 | Start Issue 1 | “เปิด Vscode แล้ว เริ่ม Issue 1” | I followed the feature-branch workflow and checked that the React, Express, Prisma, and test scaffolds matched the required structure. |
+| 3 | Continue Issue 1 | “แก้ Issue 1 ต่อ” | I reviewed the generated changes and corrected the server TypeScript output path so the build output matched the start script before opening the PR. |
+| 4 | Use stacked branches | “งั้นเริ่มทำแบบ Stacked Branch ได้เลย” | I learned why parent PRs must merge first and resynchronized dependent branches with `lab1-staging` after each merge. |
+| 5 | Check PostgreSQL | “ผมสามารถลองเข้าPostgreSQLก่อนได้มั้ย ผมไม่แน่ใจรหัส” | The first local credential assumption failed. I kept the password out of Git and moved repeatable verification to an isolated PostgreSQL database. |
+| 6 | Start Issue 3 | “เริ่ม Issue 3 แบบ Stacked Branch” | I required the Category migration and idempotent seed to run twice, then checked that exactly four distinct category names remained. |
+| 7 | Prepare evidence PR | “ทำให้ PR 9 พร้อมรีวิว” | I checked that `ai_use.md`, `reviewer.md`, and `tests.md` were complete before requesting independent peer review. |
+| 8 | Final verification | “เริ่มตรวจงานบน main” | The clean verification exposed the Prisma Client generation step. I corrected the sequence and reran builds, all seven tests, seed idempotency, and direct HTTP checks. |
 
 ## Reflection
 

--- a/docs/lab-01/reviewer.md
+++ b/docs/lab-01/reviewer.md
@@ -12,10 +12,15 @@
 | [#6](https://github.com/Davidice23/toktickit/pull/6) | `feature/2-health-check` | Approved by `Sxr1n` | Confirmed the API contract, UI states, and test coverage; the category TODO was correctly deferred to Issue 4. |
 | [#7](https://github.com/Davidice23/toktickit/pull/7) | `feature/3-category-seed` | Approved by `Sxr1n` | "W! very good to understand" |
 | [#8](https://github.com/Davidice23/toktickit/pull/8) | `feature/4-category-list` | Approved by `Sxr1n` | "Excellent! let merge it" |
+| [#9](https://github.com/Davidice23/toktickit/pull/9) | `docs/lab1-evidence` | Approved by `Sxr1n` | Confirmed that the peer-review records, test results, PR links, AI-use prompts, and reflection were complete and consistent. |
+| [#10](https://github.com/Davidice23/toktickit/pull/10) | `lab1-staging` | Approved by `Sxr1n` | Confirmed that the complete Lab 1 release matched Issues #1-#4 and was ready to merge into `main`. |
 
 ### How I responded
 
-No changes were requested on these four Pull Requests. After each approval, I checked the PR scope and mergeability, reran the relevant build and automated tests, and merged the feature into `lab1-staging`. Before the final release, I also verified the merged staging code from a clean checkout with a new PostgreSQL database.
+No changes were requested on these Pull Requests. After each approval, I
+checked the PR scope and mergeability, reran the relevant build and automated
+tests, and merged through `lab1-staging`. Before and after the release, I also
+verified the integrated code with a clean PostgreSQL database.
 
 ## Pull Request I reviewed for my peer
 

--- a/docs/lab-01/tests.md
+++ b/docs/lab-01/tests.md
@@ -14,9 +14,12 @@ All automated tests are stored under `client/tests/lab-01/` or `server/tests/lab
 | UI-03 | `client/tests/lab-01/App.test.tsx` | Testing Library + Vitest | An API failure displays Offline and a useful error message. | Passed |
 | UI-04 | `client/tests/lab-01/App.test.tsx` | Testing Library + Vitest | A successful request displays Online and all four API-provided categories. | Passed |
 
-## Clean-checkout verification
+## Final main-branch verification
 
-Verification was performed on 16 August 2026 using the final merged `lab1-staging` commit `a5742fd`, a clean dependency installation, and a new PostgreSQL 18 database.
+Verification was performed on 16 August 2026 using released `main` commit
+`47fb824`, a clean dependency installation, and an isolated PostgreSQL 18
+database. The later documentation-only evidence update does not change the
+application, database schema, or tests.
 
 Database preparation:
 
@@ -62,4 +65,5 @@ count: 4
 Account and Access, Hardware, Software, Network
 ```
 
-After the release PR is merged, run the same commands on `main` and include the terminal output or screenshots in the final PDF.
+All commands above passed on `main`. The final submission PDF includes copied
+output and browser screenshots for both the success and failure cases.


### PR DESCRIPTION
## What changed

- update README wording to describe the completed Lab 1 release;
- record final verification on released main commit `47fb824`;
- replace prompt summaries with eight actual prompts from the Codex conversation;
- add peer-review evidence for PRs #9 and #10; and
- align the submission evidence with the Lab Sheet rubric.

## Why

The final audit found that the application and Git workflow were complete, but
several documentation lines still described an earlier staging state. The
AI-use table also summarized prompts instead of showing actual prompt text.

## Project evidence

The GitHub Project is now saved as a Board view with the required columns in
order: Backlog, Specified, Started, PR Review, Fixing, and Done. Issues #1-#4
remain in Done, and their verified acceptance-criteria checkboxes are complete.

## Validation

- Client tests: 4 passed.
- Server tests: 3 passed against the isolated PostgreSQL database.
- Client production build passed.
- Server TypeScript build passed.
- Migration and idempotent seed verification passed.
- `git diff --check` passed.
- No secrets, `.env` files, `node_modules`, or build output were added.

Documentation only; application behavior and database schema are unchanged.
