### PR TITLE
release: publish reviewed Lab 1 remediation record

### DIFF
--- a/docs/lab-01/reviewer.md
+++ b/docs/lab-01/reviewer.md
@@ -14,13 +14,20 @@
 | [#8](https://github.com/Davidice23/toktickit/pull/8) | `feature/4-category-list` | Approved by `Sxr1n` | "Excellent! let merge it" |
 | [#9](https://github.com/Davidice23/toktickit/pull/9) | `docs/lab1-evidence` | Approved by `Sxr1n` | Confirmed that the peer-review records, test results, PR links, AI-use prompts, and reflection were complete and consistent. |
 | [#10](https://github.com/Davidice23/toktickit/pull/10) | `lab1-staging` | Approved by `Sxr1n` | Confirmed that the complete Lab 1 release matched Issues #1-#4 and was ready to merge into `main`. |
+| [#11](https://github.com/Davidice23/toktickit/pull/11) | `feature/lab1-final-evidence` | Approved by `Sxr1n` before merge | Confirmed that the final evidence updates matched the Lab Sheet and that all checks passed. |
+| [#12](https://github.com/Davidice23/toktickit/pull/12) | `lab1-staging` | Post-merge review comment by `lmaybelgracel` | "verygood" - submitted after the PR had accidentally been merged, so this is recorded as a post-merge audit rather than a pre-merge approval. |
 
 ### How I responded
 
-No changes were requested on these Pull Requests. After each approval, I
-checked the PR scope and mergeability, reran the relevant build and automated
+No changes were requested on the reviewed Pull Requests. After each approval,
+I checked the PR scope and mergeability, reran the relevant build and automated
 tests, and merged through `lab1-staging`. Before and after the release, I also
 verified the integrated code with a clean PostgreSQL database.
+
+PR #12 was accidentally merged before its final review. I did not rewrite or
+hide the Git history. Instead, I retained the original timestamps, requested an
+independent post-merge audit, and created a corrective documentation PR. That
+corrective PR and its subsequent release PR must both be approved before merge.
 
 ## Pull Request I reviewed for my peer
 
@@ -30,4 +37,8 @@ verified the integrated code with a clean PostgreSQL database.
 
 ## Evidence note
 
-The links above point to the GitHub review records. They show the reviewer account, review verdict, comment, reviewed commit, and merge status. Final PDF evidence should also include screenshots of the relevant review panels.
+The links above point to the GitHub review records. They show the reviewer
+account, review verdict or comment state, reviewed commit, and merge status.
+The PR #12 entry deliberately distinguishes a post-merge comment from an
+approval. Final PDF evidence should also include screenshots of the relevant
+review panels and the approved corrective workflow.


### PR DESCRIPTION
## Summary

- release the reviewed PR #12 remediation record to `main`
- preserve the original accidental-merge history without misrepresenting it
- complete the final peer-reviewed documentation workflow before generating the submission PDF

## Why

PR #12 was accidentally merged before review. PR #13 documented that event accurately and was independently approved before it was merged into `lab1-staging`. This release carries that reviewed correction to `main`.

## Impact

Documentation only. Application behavior, API endpoints, database schema, seed data, and automated tests are unchanged.

## Validation

- PR #13 was approved at commit `35e0997` before merge
- `lab1-staging` contains merge commit `92147ba`
- the release diff changes only `docs/lab-01/reviewer.md`
- previous client tests, server tests, and production builds passed

## Reviewer checklist

- [ ] PR #12 remains accurately recorded as a post-merge audit
- [ ] PR #13 approval occurred before merge
- [ ] No application code or secrets are included
- [ ] The remediation record is ready for the final PDF report
