### PR TITLE
[Lab 2] Extend database schema and idempotent seed data

### DIFF
--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -13,8 +13,9 @@ This file records peer-review evidence for Lab 2. It is updated after every feat
 
 | PR | Issue | Branch flow | Review received | Author response | Approval | Status |
 | --- | --- | --- | --- | --- | --- | --- |
-| [#24](https://github.com/Davidice23/toktickit/pull/24) | #15 | `feature/15-lab2-contract` -> `lab2-staging` | Identified Attachment-count concurrency, visible Requester-header security warning, idempotency retention/scope, query-level case matching, and requested an AC-28/AC-29 traceability check. | Initial acknowledgement was too brief. A follow-up branch resolves the four specification ambiguities; inspection confirmed AC-28 and AC-29 were already present. | Approved by `Sxr1n` on 2026-09-05 | Merged; follow-up review pending |
-| [#25](https://github.com/Davidice23/toktickit/pull/25) | #15 | `fix/15-contract-review-feedback` -> `lab2-staging` | Follow-up review requested after resolving every substantive finding from PR #24. | Resolution details are recorded below and in the PR description. | Pending | Open; awaiting peer review |
+| [#24](https://github.com/Davidice23/toktickit/pull/24) | #15 | `feature/15-lab2-contract` -> `lab2-staging` | Identified Attachment-count concurrency, visible Requester-header security warning, idempotency retention/scope, query-level case matching, and requested an AC-28/AC-29 traceability check. | Initial acknowledgement was too brief. A follow-up branch resolves the four specification ambiguities; inspection confirmed AC-28 and AC-29 were already present. | Approved by `Sxr1n` on 2026-09-05 | Merged; superseded by follow-up PR #25 |
+| [#25](https://github.com/Davidice23/toktickit/pull/25) | #15 | `fix/15-contract-review-feedback` -> `lab2-staging` | Rechecked all five findings from PR #24 and asked for direct confirmation that AC-28/AC-29 were present. | Confirmed AC-28 and AC-29 in the traceability matrix and retained the technical corrections summarized below. | Approved by `Sxr1n` on 2026-09-05 | Merged as `a682e7e` on 2026-09-05 |
+| [#26](https://github.com/Davidice23/toktickit/pull/26) | #16 | `feature/16-lab2-data` -> `lab2-staging` | Pending peer review of schema, migration, repeat-safe seed, and integration evidence. | Pending | Pending | Open; awaiting peer review |
 
 ## PR #24 Review Resolution
 
@@ -26,7 +27,7 @@ This file records peer-review evidence for Lab 2. It is updated after every feat
 
 ## Follow-up PR
 
-[PR #25](https://github.com/Davidice23/toktickit/pull/25) contains the contract corrections and the initial reviewer/AI-use evidence required by Issue #15. Implementation remains paused until the follow-up is reviewed and approved. The final review result, any additional author responses, and merge evidence will be recorded here after review.
+[PR #25](https://github.com/Davidice23/toktickit/pull/25) contains the contract corrections and the initial reviewer/AI-use evidence required by Issue #15. `Sxr1n` approved the corrected contract after the author confirmed AC-28 and AC-29 in the traceability matrix. It was merged into `lab2-staging` as `a682e7e` before Issue #16 implementation began.
 
 ## Review Practice for Remaining Issues
 

--- a/server/prisma/migrations/20260905083000_lab2_data_model/migration.sql
+++ b/server/prisma/migrations/20260905083000_lab2_data_model/migration.sql
@@ -1,0 +1,89 @@
+-- CreateEnum
+CREATE TYPE "RequestedPriority" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'URGENT');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('NEW');
+
+-- CreateEnum
+CREATE TYPE "ITPriority" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'URGENT');
+
+-- AlterTable: preserve every Lab 1 Category row while adding Lab 2 fields.
+ALTER TABLE "Category"
+ADD COLUMN "isActive" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- CreateTable
+CREATE TABLE "RequesterUser" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "RequesterUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RelatedSystem" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "RelatedSystem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" SERIAL NOT NULL,
+    "ticketNumber" TEXT,
+    "submissionKey" TEXT NOT NULL,
+    "submissionHash" TEXT NOT NULL,
+    "requesterId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+    "relatedSystemId" INTEGER NOT NULL,
+    "summary" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "requestedPriority" "RequestedPriority" NOT NULL,
+    "currentStatus" "TicketStatus" NOT NULL DEFAULT 'NEW',
+    "itPriority" "ITPriority",
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" SERIAL NOT NULL,
+    "ticketId" INTEGER NOT NULL,
+    "originalName" TEXT NOT NULL,
+    "storedName" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "removedAt" TIMESTAMP(3),
+    "removedReason" TEXT,
+    CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RequesterUser_email_key" ON "RequesterUser"("email");
+CREATE INDEX "RequesterUser_isActive_name_idx" ON "RequesterUser"("isActive", "name");
+CREATE UNIQUE INDEX "RelatedSystem_name_key" ON "RelatedSystem"("name");
+CREATE INDEX "RelatedSystem_isActive_name_idx" ON "RelatedSystem"("isActive", "name");
+CREATE INDEX "Category_isActive_name_idx" ON "Category"("isActive", "name");
+CREATE UNIQUE INDEX "Ticket_ticketNumber_key" ON "Ticket"("ticketNumber");
+CREATE UNIQUE INDEX "Ticket_requesterId_submissionKey_key" ON "Ticket"("requesterId", "submissionKey");
+CREATE INDEX "Ticket_requesterId_updatedAt_idx" ON "Ticket"("requesterId", "updatedAt");
+CREATE INDEX "Ticket_requesterId_currentStatus_idx" ON "Ticket"("requesterId", "currentStatus");
+CREATE INDEX "Ticket_requesterId_categoryId_idx" ON "Ticket"("requesterId", "categoryId");
+CREATE INDEX "Ticket_requesterId_relatedSystemId_idx" ON "Ticket"("requesterId", "relatedSystemId");
+CREATE INDEX "Ticket_requesterId_requestedPriority_idx" ON "Ticket"("requesterId", "requestedPriority");
+CREATE UNIQUE INDEX "Attachment_storedName_key" ON "Attachment"("storedName");
+CREATE INDEX "Attachment_ticketId_removedAt_idx" ON "Attachment"("ticketId", "removedAt");
+
+-- AddForeignKey (RESTRICT is intentional: Lab 2 evidence must not cascade away.)
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_relatedSystemId_fkey" FOREIGN KEY ("relatedSystemId") REFERENCES "RelatedSystem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -13,5 +13,94 @@ datasource db {
 model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  tickets   Ticket[]
+
+  @@index([isActive, name])
+}
+
+model RequesterUser {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  tickets   Ticket[]
+
+  @@index([isActive, name])
+}
+
+model RelatedSystem {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  tickets   Ticket[]
+
+  @@index([isActive, name])
+}
+
+model Ticket {
+  id                Int               @id @default(autoincrement())
+  ticketNumber      String?           @unique
+  submissionKey     String
+  submissionHash    String
+  requesterId       Int
+  categoryId        Int
+  relatedSystemId   Int
+  summary           String
+  description       String
+  requestedPriority RequestedPriority
+  currentStatus     TicketStatus      @default(NEW)
+  itPriority        ITPriority?
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+  requester         RequesterUser     @relation(fields: [requesterId], references: [id], onDelete: Restrict)
+  category          Category          @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  relatedSystem     RelatedSystem     @relation(fields: [relatedSystemId], references: [id], onDelete: Restrict)
+  attachments       Attachment[]
+
+  @@unique([requesterId, submissionKey])
+  @@index([requesterId, updatedAt])
+  @@index([requesterId, currentStatus])
+  @@index([requesterId, categoryId])
+  @@index([requesterId, relatedSystemId])
+  @@index([requesterId, requestedPriority])
+}
+
+model Attachment {
+  id            Int       @id @default(autoincrement())
+  ticketId      Int
+  originalName  String
+  storedName    String    @unique
+  mimeType      String
+  sizeBytes     Int
+  uploadedAt    DateTime  @default(now())
+  removedAt     DateTime?
+  removedReason String?
+  ticket        Ticket    @relation(fields: [ticketId], references: [id], onDelete: Restrict)
+
+  @@index([ticketId, removedAt])
+}
+
+enum RequestedPriority {
+  LOW
+  MEDIUM
+  HIGH
+  URGENT
+}
+
+enum TicketStatus {
+  NEW
+}
+
+enum ITPriority {
+  LOW
+  MEDIUM
+  HIGH
+  URGENT
 }

--- a/server/prisma/seed-data.ts
+++ b/server/prisma/seed-data.ts
@@ -1,0 +1,51 @@
+import type { PrismaClient } from "@prisma/client";
+
+export const CATEGORY_NAMES = [
+  "Account and Access",
+  "Hardware",
+  "Software",
+  "Network",
+] as const;
+
+export const RELATED_SYSTEM_NAMES = [
+  "Email and Collaboration",
+  "Enterprise Resource Planning",
+  "Human Resources Information System",
+  "Learning Management System",
+  "Network and VPN",
+  "Student Information System",
+] as const;
+
+export const REQUESTERS = [
+  { name: "Anan Chaiya", email: "anan.chaiya@example.test", isActive: true },
+  { name: "Kanya Prasert", email: "kanya.prasert@example.test", isActive: true },
+  { name: "Narin Sombat", email: "narin.sombat@example.test", isActive: true },
+  { name: "Pimchanok Dee", email: "pimchanok.dee@example.test", isActive: true },
+  { name: "Retired Requester", email: "retired.requester@example.test", isActive: false },
+] as const;
+
+export async function seedReferenceData(prisma: PrismaClient): Promise<void> {
+  for (const name of CATEGORY_NAMES) {
+    await prisma.category.upsert({
+      where: { name },
+      update: { isActive: true },
+      create: { name, isActive: true },
+    });
+  }
+
+  for (const name of RELATED_SYSTEM_NAMES) {
+    await prisma.relatedSystem.upsert({
+      where: { name },
+      update: { isActive: true },
+      create: { name, isActive: true },
+    });
+  }
+
+  for (const requester of REQUESTERS) {
+    await prisma.requesterUser.upsert({
+      where: { email: requester.email },
+      update: { name: requester.name, isActive: requester.isActive },
+      create: requester,
+    });
+  }
+}

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,27 +1,18 @@
 import { getPrisma } from "../src/prisma.js";
+import {
+  CATEGORY_NAMES,
+  RELATED_SYSTEM_NAMES,
+  REQUESTERS,
+  seedReferenceData,
+} from "./seed-data.js";
 
-// Issue 3 — seed the four supported categories.
-// The four names are: Account and Access, Hardware, Software, Network.
-// Requirement: running the seed twice must NOT create duplicates.
-// Hint: prisma.category.upsert({ where:{name}, update:{}, create:{name} }).
 async function main() {
   const prisma = getPrisma();
-  const categoryNames = [
-    "Account and Access",
-    "Hardware",
-    "Software",
-    "Network",
-  ];
+  await seedReferenceData(prisma);
 
-  for (const name of categoryNames) {
-    await prisma.category.upsert({
-      where: { name },
-      update: {},
-      create: { name },
-    });
-  }
-
-  console.log(`Seeded ${categoryNames.length} IT request categories.`);
+  console.log(
+    `Seeded ${CATEGORY_NAMES.length} categories, ${RELATED_SYSTEM_NAMES.length} related systems, and ${REQUESTERS.length} requesters.`,
+  );
 }
 
 main()

--- a/server/tests/lab-02/seed.integration.test.ts
+++ b/server/tests/lab-02/seed.integration.test.ts
@@ -1,0 +1,45 @@
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  CATEGORY_NAMES,
+  RELATED_SYSTEM_NAMES,
+  REQUESTERS,
+  seedReferenceData,
+} from "../../prisma/seed-data.js";
+import { getPrisma } from "../../src/prisma.js";
+
+afterAll(async () => {
+  await getPrisma().$disconnect();
+});
+
+describe("Lab 2 reference-data seed", () => {
+  it("is repeat-safe and preserves the required active/inactive fixtures", async () => {
+    const prisma = getPrisma();
+
+    await seedReferenceData(prisma);
+    await seedReferenceData(prisma);
+
+    const [categories, relatedSystems, requesters] = await Promise.all([
+      prisma.category.findMany({
+        where: { name: { in: [...CATEGORY_NAMES] } },
+        orderBy: { name: "asc" },
+      }),
+      prisma.relatedSystem.findMany({
+        where: { name: { in: [...RELATED_SYSTEM_NAMES] } },
+        orderBy: { name: "asc" },
+      }),
+      prisma.requesterUser.findMany({
+        where: { email: { in: REQUESTERS.map(({ email }) => email) } },
+        orderBy: { email: "asc" },
+      }),
+    ]);
+
+    expect(categories).toHaveLength(4);
+    expect(categories.every(({ isActive }) => isActive)).toBe(true);
+    expect(relatedSystems).toHaveLength(6);
+    expect(relatedSystems.every(({ isActive }) => isActive)).toBe(true);
+    expect(requesters).toHaveLength(5);
+    expect(requesters.filter(({ isActive }) => isActive)).toHaveLength(4);
+    expect(requesters.filter(({ isActive }) => !isActive)).toHaveLength(1);
+    expect(new Set(requesters.map(({ email }) => email)).size).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- extends the Prisma schema for Requesters, Related Systems, Tickets, and Attachments
- preserves the four Lab 1 Categories while adding Lab 2 activity and timestamp fields
- adds one named PostgreSQL migration with restrictive ownership-preserving foreign keys and documented indexes
- refactors deterministic reference data into a reusable, repeat-safe seed function
- adds an integration test that runs the seed twice and verifies exact fixture counts

## Verification
- `npx prisma validate` passed
- both migrations applied successfully to a clean `toktickit` PostgreSQL database
- seed ran twice without duplicates: 4 Categories, 6 Related Systems, 4 active Requesters, 1 inactive Requester
- `npm run build` passed
- `npm test` passed: 3 files, 4 tests
- `git diff --check` passed

Closes #16.