### PR TITLE
[Lab 2] Establish Zen Green UI foundation and application shell

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ type UiState = "idle" | "loading" | "success" | "error";
 export default function App() {
   const [state, setState] = useState<UiState>("idle");
   const [categories, setCategories] = useState<Category[]>([]);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   async function handleCheck() {
     setState("loading");
@@ -21,48 +22,67 @@ export default function App() {
   }
 
   return (
-    <div className="container py-5" style={{ maxWidth: 640 }}>
-      <h1 className="h3 mb-4">
-        TokTickIT <span className="text-success">IT Service Desk</span>
-      </h1>
+    <div className="app-shell">
+      <header className="app-header">
+        <a className="app-brand" href="#top" aria-label="TokTickIT home">TokTickIT</a>
+        <button
+          className="menu-toggle"
+          type="button"
+          aria-expanded={menuOpen}
+          aria-controls="primary-navigation"
+          onClick={() => setMenuOpen((open) => !open)}
+        >
+          Menu
+        </button>
+        <nav id="primary-navigation" className={`primary-navigation${menuOpen ? " is-open" : ""}`} aria-label="Primary navigation">
+          <a className="nav-link is-active" href="#my-tickets" aria-current="page" onClick={() => setMenuOpen(false)}>My Tickets</a>
+          <a className="nav-link" href="#create-ticket" onClick={() => setMenuOpen(false)}>Create Ticket</a>
+          <span className="requester-context" aria-label="Current Requester">Requester: Not selected</span>
+          <button className="nav-action" type="button" onClick={() => setMenuOpen(false)}>Change Requester</button>
+        </nav>
+      </header>
 
-      <button className="btn btn-success" onClick={handleCheck} disabled={state === "loading"}>
-        {state === "loading" ? "Loading..." : "Check System"}
-      </button>
+      <main id="top" className="app-main">
+        <section className="page-card" aria-labelledby="page-title">
+          <p className="eyebrow">IT Service Desk</p>
+          <h1 id="page-title">Requester workspace</h1>
+          <p className="page-intro">A clear, responsive workspace for creating and tracking your IT requests.</p>
 
-      {state === "loading" && (
-        <div className="alert alert-info mt-4" role="status">
-          Checking TokTickIT API...
-        </div>
-      )}
+          <button className="btn btn-primary-green" onClick={handleCheck} disabled={state === "loading"}>
+            {state === "loading" ? "Loading..." : "Check System"}
+          </button>
 
-      {state === "success" && (
-        <>
-          <div className="alert alert-success mt-4" role="status">
-            <strong>System Status:</strong> Online
-          </div>
+          {state === "loading" && (
+            <div className="state-callout state-info" role="status" aria-live="polite">
+              <strong>Loading:</strong> Checking TokTickIT API...
+            </div>
+          )}
 
-          <section aria-labelledby="category-heading">
-            <h2 id="category-heading" className="h5 mt-4">
-              IT Request Categories
-            </h2>
-            <ul className="list-group">
-              {categories.map((category) => (
-                <li className="list-group-item" key={category.id}>
-                  {category.name}
-                </li>
-              ))}
-            </ul>
-          </section>
-        </>
-      )}
+          {state === "success" && (
+            <>
+              <div className="state-callout state-success" role="status">
+                <strong>System Status:</strong> Online
+              </div>
 
-      {state === "error" && (
-        <div className="alert alert-danger mt-4" role="alert">
-          <p className="mb-1"><strong>System Status:</strong> Offline</p>
-          <p className="mb-0">Unable to connect to TokTickIT API</p>
-        </div>
-      )}
+              <section aria-labelledby="category-heading">
+                <h2 id="category-heading">IT Request Categories</h2>
+                <ul className="category-list">
+                  {categories.map((category) => (
+                    <li className="category-item" key={category.id}>{category.name}</li>
+                  ))}
+                </ul>
+              </section>
+            </>
+          )}
+
+          {state === "error" && (
+            <div className="state-callout state-error" role="alert">
+              <p><strong>System Status:</strong> Offline</p>
+              <p>Unable to connect to TokTickIT API</p>
+            </div>
+          )}
+        </section>
+      </main>
     </div>
   );
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "bootstrap/dist/css/bootstrap.min.css";
+import "./styles.css";
 import App from "./App.js";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1,0 +1,63 @@
+:root {
+  --color-primary: #006b3c;
+  --color-primary-hover: #005631;
+  --color-secondary: #0b7a46;
+  --color-pale-green: #eaf6ef;
+  --color-page: #f5f7f6;
+  --color-surface: #ffffff;
+  --color-text: #17362a;
+  --color-text-muted: #52685f;
+  --color-border: #c8d5cf;
+  --color-error: #9b1c1c;
+  --color-error-bg: #fdecec;
+  --color-success: #176b3a;
+  --color-success-bg: #eaf6ef;
+  --color-focus: #0b7a46;
+  font-family: Inter, system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--color-text);
+  background: var(--color-page);
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-width: 320px; background: var(--color-page); line-height: 1.5; }
+a { color: inherit; }
+button, a { -webkit-tap-highlight-color: transparent; }
+:focus-visible { outline: 3px solid var(--color-focus); outline-offset: 3px; }
+
+.app-shell { min-height: 100vh; }
+.app-header { display: flex; align-items: center; gap: 24px; min-height: 72px; padding: 12px 32px; color: #fff; background: var(--color-primary); }
+.app-brand { font-size: 1.35rem; font-weight: 700; text-decoration: none; white-space: nowrap; }
+.primary-navigation { display: flex; align-items: center; gap: 8px; width: 100%; }
+.nav-link, .nav-action { min-height: 44px; padding: 10px 14px; border: 0; border-radius: 8px; color: #fff; background: transparent; font: inherit; text-decoration: none; cursor: pointer; }
+.nav-link:hover, .nav-link.is-active, .nav-action:hover { background: rgba(255, 255, 255, .16); }
+.requester-context { margin-left: auto; padding: 10px 8px; font-size: .95rem; }
+.menu-toggle { display: none; min-height: 44px; margin-left: auto; padding: 8px 14px; border: 1px solid rgba(255,255,255,.65); border-radius: 8px; color: #fff; background: transparent; font: inherit; font-weight: 600; }
+.app-main { max-width: 1200px; margin: 0 auto; padding: 48px 32px; }
+.page-card { max-width: 960px; margin: 0 auto; padding: 32px; border: 1px solid var(--color-border); border-radius: 12px; background: var(--color-surface); box-shadow: 0 4px 16px rgba(23,54,42,.08); }
+.eyebrow { margin: 0 0 8px; color: var(--color-secondary); font-size: .9rem; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; }
+h1, h2 { color: var(--color-text); }
+h1 { margin: 0; font-size: clamp(1.5rem, 2.5vw, 1.875rem); }
+h2 { margin-top: 32px; font-size: 1.25rem; }
+.page-intro { max-width: 60ch; margin: 8px 0 24px; color: var(--color-text-muted); }
+.btn-primary-green { min-height: 44px; padding: 10px 18px; border: 1px solid var(--color-primary); border-radius: 8px; color: #fff; background: var(--color-primary); font-weight: 600; }
+.btn-primary-green:hover:not(:disabled) { background: var(--color-primary-hover); }
+.btn-primary-green:disabled { cursor: not-allowed; opacity: .65; }
+.state-callout { margin-top: 24px; padding: 16px; border: 1px solid; border-radius: 12px; }
+.state-callout p { margin: 0 0 4px; }
+.state-callout p:last-child { margin-bottom: 0; }
+.state-info { border-color: #8aa9a0; background: var(--color-pale-green); }
+.state-success { border-color: var(--color-success); color: var(--color-success); background: var(--color-success-bg); }
+.state-error { border-color: var(--color-error); color: var(--color-error); background: var(--color-error-bg); }
+.category-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; padding: 0; list-style: none; }
+.category-item { padding: 12px 16px; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-pale-green); }
+
+@media (max-width: 767px) {
+  .app-header { flex-wrap: wrap; gap: 8px 16px; padding: 12px 16px; }
+  .menu-toggle { display: block; }
+  .primary-navigation { display: none; flex-direction: column; align-items: stretch; gap: 4px; order: 3; padding: 8px 0 4px; }
+  .primary-navigation.is-open { display: flex; }
+  .nav-link, .nav-action, .requester-context { width: 100%; margin-left: 0; text-align: left; }
+  .app-main { padding: 24px 16px; }
+  .page-card { padding: 20px 16px; }
+  .category-list { grid-template-columns: 1fr; }
+}

--- a/client/tests/lab-02/ui-foundation.test.tsx
+++ b/client/tests/lab-02/ui-foundation.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "../../src/App.js";
+
+describe("Lab 2 UI foundation", () => {
+  it("exposes the desktop navigation and current requester context", () => {
+    render(<App />);
+
+    expect(screen.getByRole("navigation", { name: /primary navigation/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "My Tickets" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByLabelText("Current Requester")).toHaveTextContent("Not selected");
+    expect(screen.getByRole("button", { name: "Change Requester" })).toBeInTheDocument();
+  });
+
+  it("toggles the labeled mobile menu with aria-expanded", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    const menu = screen.getByRole("button", { name: "Menu" });
+
+    expect(menu).toHaveAttribute("aria-expanded", "false");
+    await user.click(menu);
+    expect(menu).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("link", { name: "Create Ticket" })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- adds the approved Zen Green design tokens and accessible focus treatment
- establishes the responsive TokTickIT shell with My Tickets, Create Ticket, current Requester, and Change Requester navigation
- adds a labeled mobile Menu with `aria-expanded` and keyboard-reachable actions
- keeps the Lab 1 system check working while introducing reusable state callouts and category surfaces
- adds UI foundation tests for navigation, requester context, and mobile menu behavior

## Verification
- `npm test` passed: 2 files, 6 tests
- `npm run build` passed
- `git diff --check` passed
- desktop/tablet/mobile CSS breakpoints follow `ui-spec.md`
- no authentication or IT Staff functionality was introduced

Closes #17.