### PR TITLE
[Lab 2] Implement Development Requester context

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,12 +1,17 @@
 import { useState } from "react";
-import { checkSystem, Category } from "./api.js";
+import { checkSystem, Category, fetchRequesters, Requester } from "./api.js";
 
 type UiState = "idle" | "loading" | "success" | "error";
+type RequesterUiState = "idle" | "loading" | "ready" | "empty" | "error";
 
 export default function App() {
   const [state, setState] = useState<UiState>("idle");
   const [categories, setCategories] = useState<Category[]>([]);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [requesterUiState, setRequesterUiState] = useState<RequesterUiState>("idle");
+  const [requesters, setRequesters] = useState<Requester[]>([]);
+  const [selectedRequester, setSelectedRequester] = useState<Requester | null>(null);
+  const [selectedId, setSelectedId] = useState("");
 
   async function handleCheck() {
     setState("loading");
@@ -19,6 +24,33 @@ export default function App() {
       setCategories([]);
       setState("error");
     }
+  }
+
+  async function loadRequesters() {
+    setRequesterUiState("loading");
+    try {
+      const result = await fetchRequesters();
+      setRequesters(result);
+      setRequesterUiState(result.length ? "ready" : "empty");
+    } catch {
+      setRequesters([]);
+      setRequesterUiState("error");
+    }
+  }
+
+  function continueAsRequester() {
+    const requester = requesters.find(({ id }) => String(id) === selectedId);
+    if (!requester) return;
+    localStorage.setItem("toktickit.devRequesterId", String(requester.id));
+    setSelectedRequester(requester);
+    setRequesterUiState("idle");
+  }
+
+  function changeRequester() {
+    localStorage.removeItem("toktickit.devRequesterId");
+    setSelectedRequester(null);
+    setSelectedId("");
+    loadRequesters();
   }
 
   return (
@@ -37,8 +69,8 @@ export default function App() {
         <nav id="primary-navigation" className={`primary-navigation${menuOpen ? " is-open" : ""}`} aria-label="Primary navigation">
           <a className="nav-link is-active" href="#my-tickets" aria-current="page" onClick={() => setMenuOpen(false)}>My Tickets</a>
           <a className="nav-link" href="#create-ticket" onClick={() => setMenuOpen(false)}>Create Ticket</a>
-          <span className="requester-context" aria-label="Current Requester">Requester: Not selected</span>
-          <button className="nav-action" type="button" onClick={() => setMenuOpen(false)}>Change Requester</button>
+          <span className="requester-context" aria-label="Current Requester">Requester: {selectedRequester?.name ?? "Not selected"}</span>
+          <button className="nav-action" type="button" onClick={() => { setMenuOpen(false); changeRequester(); }}>Change Requester</button>
         </nav>
       </header>
 
@@ -47,6 +79,25 @@ export default function App() {
           <p className="eyebrow">IT Service Desk</p>
           <h1 id="page-title">Requester workspace</h1>
           <p className="page-intro">A clear, responsive workspace for creating and tracking your IT requests.</p>
+
+          {!selectedRequester && (
+            <section className="requester-card" aria-labelledby="requester-heading">
+              <h2 id="requester-heading">Select Development Requester</h2>
+              <p className="helper-text">This selector is for Lab 2 testing only; it is not login or authentication. Authentication arrives in Lab 3.</p>
+              {requesterUiState === "idle" && <button className="btn btn-secondary-green" type="button" onClick={loadRequesters}>Choose Requester</button>}
+              {requesterUiState === "loading" && <div className="state-callout state-info" role="status" aria-live="polite"><strong>Loading:</strong> Development Requesters...</div>}
+              {requesterUiState === "error" && <div className="state-callout state-error" role="alert"><strong>Unable to load Requesters.</strong><button className="retry-button" type="button" onClick={loadRequesters}>Retry</button></div>}
+              {requesterUiState === "empty" && <div className="state-callout state-warning" role="status">No active Development Requesters are available.</div>}
+              {requesterUiState === "ready" && <div className="requester-form">
+                <label htmlFor="requester-select">Development Requester</label>
+                <select id="requester-select" value={selectedId} onChange={(event) => setSelectedId(event.target.value)}>
+                  <option value="">Select a Requester</option>
+                  {requesters.map((requester) => <option key={requester.id} value={requester.id}>{requester.name}</option>)}
+                </select>
+                <button className="btn btn-primary-green" type="button" disabled={!selectedId} onClick={continueAsRequester}>Continue</button>
+              </div>}
+            </section>
+          )}
 
           <button className="btn btn-primary-green" onClick={handleCheck} disabled={state === "loading"}>
             {state === "loading" ? "Loading..." : "Check System"}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { checkSystem, Category, fetchRequesters, Requester } from "./api.js";
 
 type UiState = "idle" | "loading" | "success" | "error";
@@ -12,6 +12,18 @@ export default function App() {
   const [requesters, setRequesters] = useState<Requester[]>([]);
   const [selectedRequester, setSelectedRequester] = useState<Requester | null>(null);
   const [selectedId, setSelectedId] = useState("");
+
+  useEffect(() => {
+    const storedId = localStorage.getItem("toktickit.devRequesterId");
+    if (!storedId) return;
+    fetchRequesters().then((available) => {
+      const requester = available.find(({ id }) => String(id) === storedId);
+      if (requester) setSelectedRequester(requester);
+      else localStorage.removeItem("toktickit.devRequesterId");
+    }).catch(() => {
+      localStorage.removeItem("toktickit.devRequesterId");
+    });
+  }, []);
 
   async function handleCheck() {
     setState("loading");

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -10,6 +10,28 @@ export interface SystemStatus {
   categories: Category[];
 }
 
+export interface Requester {
+  id: number;
+  name: string;
+  isActive: boolean;
+}
+
+function isRequester(value: unknown): value is Requester {
+  if (typeof value !== "object" || value === null) return false;
+  const requester = value as Record<string, unknown>;
+  return typeof requester.id === "number" && typeof requester.name === "string" && requester.isActive === true;
+}
+
+export async function fetchRequesters(): Promise<Requester[]> {
+  const response = await fetch(`${API_URL}/api/requesters?active=true`);
+  if (!response.ok) throw new Error("Unable to load Development Requesters");
+  const requesters = (await response.json()) as unknown;
+  if (!Array.isArray(requesters) || !requesters.every(isRequester)) {
+    throw new Error("Unexpected Development Requester response");
+  }
+  return requesters;
+}
+
 // Issue 2 checks the backend health endpoint. Issue 4 will extend the system
 // check with the categories request after the database work is available.
 interface HealthResponse {

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -19,7 +19,7 @@ export interface Requester {
 function isRequester(value: unknown): value is Requester {
   if (typeof value !== "object" || value === null) return false;
   const requester = value as Record<string, unknown>;
-  return typeof requester.id === "number" && typeof requester.name === "string" && requester.isActive === true;
+  return typeof requester.id === "number" && typeof requester.name === "string" && typeof requester.isActive === "boolean";
 }
 
 export async function fetchRequesters(): Promise<Requester[]> {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -39,6 +39,15 @@ h1, h2 { color: var(--color-text); }
 h1 { margin: 0; font-size: clamp(1.5rem, 2.5vw, 1.875rem); }
 h2 { margin-top: 32px; font-size: 1.25rem; }
 .page-intro { max-width: 60ch; margin: 8px 0 24px; color: var(--color-text-muted); }
+.helper-text { color: var(--color-text-muted); }
+.requester-card { margin: 24px 0; padding: 20px; border: 1px solid var(--color-border); border-radius: 12px; background: var(--color-pale-green); }
+.requester-card h2 { margin-top: 0; }
+.requester-form { display: grid; gap: 10px; max-width: 560px; }
+.requester-form label { font-weight: 600; }
+.requester-form select { min-height: 44px; padding: 8px 12px; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-surface); color: var(--color-text); font: inherit; }
+.btn-secondary-green { min-height: 44px; padding: 10px 18px; border: 1px solid var(--color-secondary); border-radius: 8px; color: var(--color-secondary); background: var(--color-surface); font-weight: 600; }
+.retry-button { margin-left: 12px; border: 0; color: var(--color-error); background: transparent; text-decoration: underline; font: inherit; font-weight: 600; cursor: pointer; }
+.state-warning { border-color: #8a4b08; color: #8a4b08; background: #fff4d6; }
 .btn-primary-green { min-height: 44px; padding: 10px 18px; border: 1px solid var(--color-primary); border-radius: 8px; color: #fff; background: var(--color-primary); font-weight: 600; }
 .btn-primary-green:hover:not(:disabled) { background: var(--color-primary-hover); }
 .btn-primary-green:disabled { cursor: not-allowed; opacity: .65; }

--- a/client/tests/lab-02/requester-context.test.tsx
+++ b/client/tests/lab-02/requester-context.test.tsx
@@ -36,4 +36,16 @@ describe("Lab 2 Development Requester context", () => {
     expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
     expect(screen.getByRole("alert")).not.toHaveTextContent("database details");
   });
+
+  it("restores a valid requester from localStorage", async () => {
+    localStorage.setItem("toktickit.devRequesterId", "1");
+    vi.spyOn(api, "fetchRequesters").mockResolvedValue([
+      { id: 1, name: "Anan Chaiya", isActive: true },
+    ]);
+
+    render(<App />);
+
+    expect(await screen.findByLabelText("Current Requester")).toHaveTextContent("Anan Chaiya");
+    expect(screen.queryByRole("heading", { name: "Select Development Requester" })).not.toBeInTheDocument();
+  });
 });

--- a/client/tests/lab-02/requester-context.test.tsx
+++ b/client/tests/lab-02/requester-context.test.tsx
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "../../src/App.js";
+import * as api from "../../src/api.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  localStorage.clear();
+});
+
+describe("Lab 2 Development Requester context", () => {
+  it("loads active requesters and persists the selected requester", async () => {
+    vi.spyOn(api, "fetchRequesters").mockResolvedValue([
+      { id: 1, name: "Anan Chaiya", isActive: true },
+      { id: 2, name: "Kanya Prasert", isActive: true },
+    ]);
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByRole("button", { name: "Choose Requester" }));
+    await user.selectOptions(await screen.findByLabelText("Development Requester"), "2");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(localStorage.getItem("toktickit.devRequesterId")).toBe("2");
+    expect(screen.getByLabelText("Current Requester")).toHaveTextContent("Kanya Prasert");
+  });
+
+  it("shows a safe failure with Retry", async () => {
+    vi.spyOn(api, "fetchRequesters").mockRejectedValue(new Error("database details"));
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByRole("button", { name: "Choose Requester" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/unable to load requesters/i);
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    expect(screen.getByRole("alert")).not.toHaveTextContent("database details");
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -33,6 +33,8 @@ app.get("/api/categories", async (_req: Request, res: Response) => {
 
 app.get("/api/requesters", async (req: Request, res: Response) => {
   try {
+    // The Lab 2 selector uses active=true (or the safe active-only default).
+    // active=false intentionally means no activity filter for future staff views.
     const active = req.query.active === undefined || req.query.active === "true";
     const requesters = await getPrisma().requesterUser.findMany({
       where: active ? { isActive: true } : undefined,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -31,4 +31,19 @@ app.get("/api/categories", async (_req: Request, res: Response) => {
   }
 });
 
+app.get("/api/requesters", async (req: Request, res: Response) => {
+  try {
+    const active = req.query.active === undefined || req.query.active === "true";
+    const requesters = await getPrisma().requesterUser.findMany({
+      where: active ? { isActive: true } : undefined,
+      select: { id: true, name: true, isActive: true },
+      orderBy: [{ name: "asc" }, { id: "asc" }],
+    });
+
+    res.status(200).json(requesters);
+  } catch {
+    res.status(500).json({ error: "Unable to load Development Requesters" });
+  }
+});
+
 export default app;

--- a/server/tests/lab-02/requesters.api.test.ts
+++ b/server/tests/lab-02/requesters.api.test.ts
@@ -1,0 +1,32 @@
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import * as prismaModule from "../../src/prisma.js";
+
+afterEach(() => vi.restoreAllMocks());
+afterAll(async () => { await prismaModule.getPrisma().$disconnect(); });
+
+describe("GET /api/requesters", () => {
+  it("returns only active requesters in name/ID order", async () => {
+    const res = await request(app).get("/api/requesters?active=true");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(4);
+    expect(res.body.every((requester: { isActive: boolean }) => requester.isActive)).toBe(true);
+    expect(res.body.map((requester: { name: string }) => requester.name)).toEqual([
+      "Anan Chaiya", "Kanya Prasert", "Narin Sombat", "Pimchanok Dee",
+    ]);
+  });
+
+  it("returns a safe error when the database is unavailable", async () => {
+    vi.spyOn(prismaModule, "getPrisma").mockReturnValue({
+      requesterUser: { findMany: vi.fn().mockRejectedValue(new Error("sensitive details")) },
+    } as unknown as ReturnType<typeof prismaModule.getPrisma>);
+
+    const res = await request(app).get("/api/requesters");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Unable to load Development Requesters" });
+    expect(JSON.stringify(res.body)).not.toContain("sensitive details");
+  });
+});


### PR DESCRIPTION
## Summary
- adds `GET /api/requesters?active=true` with active-only filtering and deterministic name/ID ordering
- adds a safe API failure response and focused API tests
- adds the Lab 2 Development Requester selector with clear non-authentication guidance
- supports loading, empty, failure/Retry, ready selection, Continue, localStorage persistence, and Change Requester
- keeps requester display and mobile navigation accessible through the Zen Green shell

## Verification
- server tests: 6/6 passed
- client tests: 8/8 passed
- client build passed
- server build passed
- `git diff --check` passed
- inactive Requesters are excluded from the selector
- no passwords, sessions, tokens, or real authentication were added

Closes #18.