### PR TITLE
[Lab 2] Implement Requester ticket creation workflow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { checkSystem, Category, fetchRequesters, Requester } from "./api.js";
+import CreateTicket from "./CreateTicket.js";
 
 type UiState = "idle" | "loading" | "success" | "error";
 type RequesterUiState = "idle" | "loading" | "ready" | "empty" | "error";
@@ -11,6 +12,7 @@ export default function App() {
   const [requesterUiState, setRequesterUiState] = useState<RequesterUiState>("idle");
   const [requesters, setRequesters] = useState<Requester[]>([]);
   const [selectedRequester, setSelectedRequester] = useState<Requester | null>(null);
+  const [createMode, setCreateMode] = useState(false);
   const [selectedId, setSelectedId] = useState("");
 
   useEffect(() => {
@@ -79,10 +81,10 @@ export default function App() {
           Menu
         </button>
         <nav id="primary-navigation" className={`primary-navigation${menuOpen ? " is-open" : ""}`} aria-label="Primary navigation">
-          <a className="nav-link is-active" href="#my-tickets" aria-current="page" onClick={() => setMenuOpen(false)}>My Tickets</a>
-          <a className="nav-link" href="#create-ticket" onClick={() => setMenuOpen(false)}>Create Ticket</a>
+          <a className={`nav-link${!createMode ? " is-active" : ""}`} href="#my-tickets" aria-current={!createMode ? "page" : undefined} onClick={() => { setCreateMode(false); setMenuOpen(false); }}>My Tickets</a>
+          <a className={`nav-link${createMode ? " is-active" : ""}`} href="#create-ticket" aria-current={createMode ? "page" : undefined} onClick={() => { setCreateMode(true); setMenuOpen(false); }}>Create Ticket</a>
           <span className="requester-context" aria-label="Current Requester">Requester: {selectedRequester?.name ?? "Not selected"}</span>
-          <button className="nav-action" type="button" onClick={() => { setMenuOpen(false); changeRequester(); }}>Change Requester</button>
+          <button className="nav-action" type="button" onClick={() => { setMenuOpen(false); setCreateMode(false); changeRequester(); }}>Change Requester</button>
         </nav>
       </header>
 
@@ -91,6 +93,8 @@ export default function App() {
           <p className="eyebrow">IT Service Desk</p>
           <h1 id="page-title">Requester workspace</h1>
           <p className="page-intro">A clear, responsive workspace for creating and tracking your IT requests.</p>
+
+          {selectedRequester && createMode && <CreateTicket requesterId={selectedRequester.id} />}
 
           {!selectedRequester && (
             <section className="requester-card" aria-labelledby="requester-heading">

--- a/client/src/CreateTicket.tsx
+++ b/client/src/CreateTicket.tsx
@@ -1,0 +1,64 @@
+import { FormEvent, useEffect, useState } from "react";
+import { Category, createTicket, fetchCategories, fetchRelatedSystems, RelatedSystem, CreatedTicket } from "./api.js";
+
+interface Props { requesterId: number; }
+
+export default function CreateTicket({ requesterId }: Props) {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [systems, setSystems] = useState<RelatedSystem[]>([]);
+  const [summary, setSummary] = useState("");
+  const [description, setDescription] = useState("");
+  const [categoryId, setCategoryId] = useState("");
+  const [relatedSystemId, setRelatedSystemId] = useState("");
+  const [priority, setPriority] = useState("");
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [status, setStatus] = useState<"loading" | "ready" | "error" | "submitting" | "success">("loading");
+  const [created, setCreated] = useState<CreatedTicket | null>(null);
+
+  useEffect(() => {
+    Promise.all([fetchCategories(), fetchRelatedSystems()]).then(([loadedCategories, loadedSystems]) => {
+      setCategories(loadedCategories); setSystems(loadedSystems); setStatus("ready");
+    }).catch(() => setStatus("error"));
+  }, []);
+
+  function validate() {
+    const next: Record<string, string> = {};
+    if (!categoryId) next.categoryId = "Category is required";
+    if (!relatedSystemId) next.relatedSystemId = "Related System is required";
+    if (!summary.trim() || summary.trim().length < 5 || summary.trim().length > 120) next.summary = "Summary must contain 5-120 characters";
+    if (!description.trim() || description.trim().length < 10 || description.trim().length > 5000) next.description = "Description must contain 10-5000 characters";
+    if (!priority) next.priority = "Requested Priority is required";
+    setErrors(next); return next;
+  }
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    if (Object.keys(validate()).length) return;
+    setStatus("submitting");
+    try {
+      const ticket = await createTicket(requesterId, { categoryId: Number(categoryId), relatedSystemId: Number(relatedSystemId), summary: summary.trim(), description: description.trim(), requestedPriority: priority }, crypto.randomUUID());
+      setCreated(ticket); setStatus("success");
+    } catch (error) {
+      setErrors((error as Error & { fields?: Record<string, string> }).fields ?? {}); setStatus("ready");
+    }
+  }
+
+  if (status === "success" && created) return <div className="state-callout state-success" role="status"><strong>Ticket created:</strong> {created.ticketNumber}<p>{created.summary}</p><button type="button" className="btn btn-secondary-green" onClick={() => { setCreated(null); setSummary(""); setDescription(""); setCategoryId(""); setRelatedSystemId(""); setPriority(""); setStatus("ready"); }}>Create Another Ticket</button></div>;
+  if (status === "loading") return <div className="state-callout state-info" role="status">Loading Categories and Related Systems...</div>;
+  if (status === "error") return <div className="state-callout state-error" role="alert">Unable to load reference data. <button type="button" className="retry-button" onClick={() => window.location.reload()}>Retry</button></div>;
+  return <form className="ticket-form" onSubmit={submit} noValidate>
+    <h2 id="create-ticket-heading">Create Ticket</h2>
+    <p className="helper-text">Ticket Number and Ticket Date are generated after submission.</p>
+    <label htmlFor="ticket-category">Category</label>
+    <select id="ticket-category" value={categoryId} onChange={(event) => setCategoryId(event.target.value)} aria-invalid={Boolean(errors.categoryId)} aria-describedby={errors.categoryId ? "category-error" : undefined}><option value="">Select a Category</option>{categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}</select>
+    {errors.categoryId && <span id="category-error" className="field-error">{errors.categoryId}</span>}
+    <label htmlFor="ticket-system">Related System</label>
+    <select id="ticket-system" value={relatedSystemId} onChange={(event) => setRelatedSystemId(event.target.value)} aria-invalid={Boolean(errors.relatedSystemId)}><option value="">Select a Related System</option>{systems.map((system) => <option key={system.id} value={system.id}>{system.name}</option>)}</select>
+    {errors.relatedSystemId && <span className="field-error">{errors.relatedSystemId}</span>}
+    <label htmlFor="ticket-priority">Requested Priority</label>
+    <select id="ticket-priority" value={priority} onChange={(event) => setPriority(event.target.value)}><option value="">Select Priority</option>{["LOW", "MEDIUM", "HIGH", "URGENT"].map((value) => <option key={value} value={value}>{value}</option>)}</select>
+    <label htmlFor="ticket-summary">Summary <span aria-hidden="true">*</span></label><input id="ticket-summary" value={summary} onChange={(event) => setSummary(event.target.value)} aria-invalid={Boolean(errors.summary)} />{errors.summary && <span className="field-error">{errors.summary}</span>}
+    <label htmlFor="ticket-description">Description <span aria-hidden="true">*</span></label><textarea id="ticket-description" value={description} onChange={(event) => setDescription(event.target.value)} aria-invalid={Boolean(errors.description)} />{errors.description && <span className="field-error">{errors.description}</span>}
+    <button className="btn btn-primary-green" type="submit" disabled={status === "submitting"}>{status === "submitting" ? "Submitting..." : "Submit Ticket"}</button>
+  </form>;
+}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -16,6 +16,40 @@ export interface Requester {
   isActive: boolean;
 }
 
+export interface RelatedSystem { id: number; name: string; isActive: boolean }
+export interface CreatedTicket { id: number; ticketNumber: string; requesterId: number; summary: string; currentStatus: string; createdAt: string }
+
+export async function fetchCategories(): Promise<Category[]> {
+  const response = await fetch(`${API_URL}/api/categories?active=true`);
+  if (!response.ok) throw new Error("Unable to load Categories");
+  const values = (await response.json()) as unknown;
+  if (!Array.isArray(values) || !values.every(isCategory)) throw new Error("Unexpected Category response");
+  return values;
+}
+
+export async function fetchRelatedSystems(): Promise<RelatedSystem[]> {
+  const response = await fetch(`${API_URL}/api/related-systems?active=true`);
+  if (!response.ok) throw new Error("Unable to load Related Systems");
+  const values = (await response.json()) as unknown;
+  if (!Array.isArray(values) || !values.every((value) => typeof value === "object" && value !== null && typeof (value as Record<string, unknown>).id === "number" && typeof (value as Record<string, unknown>).name === "string")) throw new Error("Unexpected Related System response");
+  return values as RelatedSystem[];
+}
+
+export async function createTicket(requesterId: number, body: { categoryId: number; relatedSystemId: number; summary: string; description: string; requestedPriority: string }, idempotencyKey: string): Promise<CreatedTicket> {
+  const response = await fetch(`${API_URL}/api/tickets`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-Requester-Id": String(requesterId), "Idempotency-Key": idempotencyKey },
+    body: JSON.stringify(body),
+  });
+  const payload = await response.json() as { data?: CreatedTicket; error?: string; fields?: Record<string, string> };
+  if (!response.ok || !payload.data) {
+    const error = new Error(payload.error ?? "Unable to create Ticket") as Error & { fields?: Record<string, string> };
+    error.fields = payload.fields;
+    throw error;
+  }
+  return payload.data;
+}
+
 function isRequester(value: unknown): value is Requester {
   if (typeof value !== "object" || value === null) return false;
   const requester = value as Record<string, unknown>;

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -48,6 +48,13 @@ h2 { margin-top: 32px; font-size: 1.25rem; }
 .btn-secondary-green { min-height: 44px; padding: 10px 18px; border: 1px solid var(--color-secondary); border-radius: 8px; color: var(--color-secondary); background: var(--color-surface); font-weight: 600; }
 .retry-button { margin-left: 12px; border: 0; color: var(--color-error); background: transparent; text-decoration: underline; font: inherit; font-weight: 600; cursor: pointer; }
 .state-warning { border-color: #8a4b08; color: #8a4b08; background: #fff4d6; }
+.ticket-form { display: grid; gap: 10px; margin-top: 24px; }
+.ticket-form h2 { margin: 0 0 4px; }
+.ticket-form label { margin-top: 8px; font-weight: 600; }
+.ticket-form input, .ticket-form select, .ticket-form textarea { min-height: 44px; padding: 9px 12px; border: 1px solid var(--color-border); border-radius: 8px; color: var(--color-text); background: var(--color-surface); font: inherit; }
+.ticket-form textarea { min-height: 140px; resize: vertical; }
+.ticket-form [aria-invalid="true"] { border-color: var(--color-error); }
+.field-error { color: var(--color-error); font-size: .9rem; }
 .btn-primary-green { min-height: 44px; padding: 10px 18px; border: 1px solid var(--color-primary); border-radius: 8px; color: #fff; background: var(--color-primary); font-weight: 600; }
 .btn-primary-green:hover:not(:disabled) { background: var(--color-primary-hover); }
 .btn-primary-green:disabled { cursor: not-allowed; opacity: .65; }

--- a/client/tests/lab-02/create-ticket.test.tsx
+++ b/client/tests/lab-02/create-ticket.test.tsx
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "../../src/App.js";
+import * as api from "../../src/api.js";
+
+afterEach(() => { vi.restoreAllMocks(); localStorage.clear(); });
+
+describe("Lab 2 Create Ticket", () => {
+  it("loads reference data, validates fields, and shows the created Ticket", async () => {
+    vi.spyOn(api, "fetchRequesters").mockResolvedValue([{ id: 1, name: "Anan Chaiya", isActive: true }]);
+    vi.spyOn(api, "fetchCategories").mockResolvedValue([{ id: 2, name: "Hardware" }]);
+    vi.spyOn(api, "fetchRelatedSystems").mockResolvedValue([{ id: 7, name: "Network and VPN", isActive: true }]);
+    vi.spyOn(api, "createTicket").mockResolvedValue({ id: 1, ticketNumber: "TKT-000001", requesterId: 1, summary: "Printer issue", currentStatus: "NEW", createdAt: "2026-09-05T00:00:00Z" });
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(screen.getByRole("button", { name: "Choose Requester" }));
+    await user.selectOptions(await screen.findByLabelText("Development Requester"), "1");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await user.click(screen.getByRole("link", { name: "Create Ticket" }));
+    await screen.findByRole("heading", { name: "Create Ticket" });
+
+    await user.click(screen.getByRole("button", { name: "Submit Ticket" }));
+    expect(await screen.findByText("Summary must contain 5-120 characters")).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText("Category"), "2");
+    await user.selectOptions(screen.getByLabelText("Related System"), "7");
+    await user.selectOptions(screen.getByLabelText("Requested Priority"), "MEDIUM");
+    await user.type(screen.getByLabelText(/Summary/), "Printer issue");
+    await user.type(screen.getByLabelText(/Description/), "The office printer cannot connect to the network.");
+    await user.click(screen.getByRole("button", { name: "Submit Ticket" }));
+    expect(await screen.findByText("Ticket created:")).toBeInTheDocument();
+    expect(screen.getByText("TKT-000001")).toBeInTheDocument();
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,5 +1,7 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
+import { createHash, randomUUID } from "node:crypto";
+import { RequestedPriority } from "@prisma/client";
 import { getPrisma } from "./prisma.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
@@ -45,6 +47,127 @@ app.get("/api/requesters", async (req: Request, res: Response) => {
     res.status(200).json(requesters);
   } catch {
     res.status(500).json({ error: "Unable to load Development Requesters" });
+  }
+});
+
+const ticketDetailSelect = {
+  id: true,
+  ticketNumber: true,
+  requesterId: true,
+  categoryId: true,
+  relatedSystemId: true,
+  summary: true,
+  description: true,
+  requestedPriority: true,
+  currentStatus: true,
+  itPriority: true,
+  createdAt: true,
+  updatedAt: true,
+  requester: { select: { id: true, name: true, email: true } },
+  category: { select: { id: true, name: true } },
+  relatedSystem: { select: { id: true, name: true } },
+} as const;
+
+function positiveInteger(value: unknown): number | null {
+  if (typeof value === "number") return Number.isSafeInteger(value) && value > 0 ? value : null;
+  if (typeof value !== "string" || !/^[1-9]\d*$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeText(value: unknown): string | null {
+  return typeof value === "string" ? value.trim() : null;
+}
+
+function validationError(res: Response, fields: Record<string, string>) {
+  return res.status(400).json({ error: "Validation failed", fields });
+}
+
+app.post("/api/tickets", async (req: Request, res: Response) => {
+  const requesterId = positiveInteger(req.header("X-Requester-Id"));
+  const submissionKey = normalizeText(req.header("Idempotency-Key"));
+  const body = req.body as Record<string, unknown>;
+  const fields: Record<string, string> = {};
+
+  if (!requesterId) fields.requesterId = "X-Requester-Id must be a positive integer";
+  if (!submissionKey || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(submissionKey)) {
+    fields.idempotencyKey = "Idempotency-Key must be a UUID";
+  }
+
+  const categoryId = positiveInteger(body.categoryId);
+  const relatedSystemId = positiveInteger(body.relatedSystemId);
+  const summary = normalizeText(body.summary);
+  const description = normalizeText(body.description);
+  const requestedPriority = body.requestedPriority;
+  if (!categoryId) fields.categoryId = "Category is required";
+  if (!relatedSystemId) fields.relatedSystemId = "Related System is required";
+  if (!summary || summary.length < 5 || summary.length > 120) fields.summary = "Summary must contain 5-120 characters";
+  if (!description || description.length < 10 || description.length > 5000) fields.description = "Description must contain 10-5000 characters";
+  if (typeof requestedPriority !== "string" || !Object.values(RequestedPriority).includes(requestedPriority as RequestedPriority)) {
+    fields.requestedPriority = "Requested Priority must be LOW, MEDIUM, HIGH, or URGENT";
+  }
+  if (Object.keys(fields).length) return validationError(res, fields);
+
+  const validCategoryId = categoryId as number;
+  const validRelatedSystemId = relatedSystemId as number;
+  const validRequesterId = requesterId as number;
+  const validSummary = summary as string;
+  const validDescription = description as string;
+  const validSubmissionKey = submissionKey as string;
+
+  const canonicalPayload = JSON.stringify({ categoryId: validCategoryId, relatedSystemId: validRelatedSystemId, summary: validSummary, description: validDescription, requestedPriority });
+  const submissionHash = createHash("sha256").update(canonicalPayload).digest("hex");
+
+  try {
+    const prisma = getPrisma();
+    const requester = await prisma.requesterUser.findFirst({ where: { id: validRequesterId, isActive: true }, select: { id: true } });
+    if (!requester) return validationError(res, { requesterId: "Requester is missing or inactive" });
+
+    const [category, relatedSystem] = await Promise.all([
+      prisma.category.findFirst({ where: { id: validCategoryId, isActive: true }, select: { id: true } }),
+      prisma.relatedSystem.findFirst({ where: { id: validRelatedSystemId, isActive: true }, select: { id: true } }),
+    ]);
+    if (!category) fields.categoryId = "Category is missing or inactive";
+    if (!relatedSystem) fields.relatedSystemId = "Related System is missing or inactive";
+    if (Object.keys(fields).length) return validationError(res, fields);
+
+    const existing = await prisma.ticket.findUnique({
+      where: { requesterId_submissionKey: { requesterId: validRequesterId, submissionKey: validSubmissionKey } },
+      select: { submissionHash: true, id: true },
+    });
+    if (existing) {
+      if (existing.submissionHash !== submissionHash) return res.status(409).json({ error: "Idempotency-Key was already used with a different request" });
+      const replay = await prisma.ticket.findUnique({ where: { id: existing.id }, select: ticketDetailSelect });
+      res.setHeader("Idempotent-Replay", "true");
+      return res.status(200).json({ data: replay });
+    }
+
+    const ticket = await prisma.$transaction(async (tx) => {
+      const created = await tx.ticket.create({
+        data: {
+          ticketNumber: null,
+          submissionKey: validSubmissionKey,
+          submissionHash,
+          requesterId: validRequesterId,
+          categoryId: validCategoryId,
+          relatedSystemId: validRelatedSystemId,
+          summary: validSummary,
+          description: validDescription,
+          requestedPriority: requestedPriority as RequestedPriority,
+        },
+        select: { id: true },
+      });
+      return tx.ticket.update({
+        where: { id: created.id },
+        data: { ticketNumber: `TKT-${String(created.id).padStart(6, "0")}` },
+        select: ticketDetailSelect,
+      });
+    });
+    return res.status(201).json({ data: ticket });
+  } catch (error) {
+    const correlationId = randomUUID();
+    console.error(`[${correlationId}] ticket creation failed`, error);
+    return res.status(500).json({ error: "Unable to create Ticket", correlationId });
   }
 });
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -50,6 +50,20 @@ app.get("/api/requesters", async (req: Request, res: Response) => {
   }
 });
 
+app.get("/api/related-systems", async (req: Request, res: Response) => {
+  try {
+    const active = req.query.active === undefined || req.query.active === "true";
+    const systems = await getPrisma().relatedSystem.findMany({
+      where: active ? { isActive: true } : undefined,
+      select: { id: true, name: true, isActive: true },
+      orderBy: [{ name: "asc" }, { id: "asc" }],
+    });
+    res.status(200).json(systems);
+  } catch {
+    res.status(500).json({ error: "Unable to load Related Systems" });
+  }
+});
+
 const ticketDetailSelect = {
   id: true,
   ticketNumber: true,

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import request from "supertest";
+import { randomUUID } from "node:crypto";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+
+const prisma = getPrisma();
+let requesterId: number;
+let categoryId: number;
+let relatedSystemId: number;
+
+beforeAll(async () => {
+  const [requester, category, system] = await Promise.all([
+    prisma.requesterUser.findFirstOrThrow({ where: { isActive: true }, orderBy: { id: "asc" } }),
+    prisma.category.findFirstOrThrow({ where: { isActive: true }, orderBy: { id: "asc" } }),
+    prisma.relatedSystem.findFirstOrThrow({ where: { isActive: true }, orderBy: { id: "asc" } }),
+  ]);
+  requesterId = requester.id;
+  categoryId = category.id;
+  relatedSystemId = system.id;
+});
+
+afterAll(async () => { await prisma.$disconnect(); });
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    categoryId,
+    relatedSystemId,
+    summary: "Laptop battery drains quickly",
+    description: "Battery capacity falls from 100% to 20% in one hour.",
+    requestedPriority: "MEDIUM",
+    ...overrides,
+  };
+}
+
+describe("POST /api/tickets", () => {
+  it("creates one owned NEW Ticket with a backend number", async () => {
+    const key = randomUUID();
+    const res = await request(app).post("/api/tickets").set("X-Requester-Id", String(requesterId)).set("Idempotency-Key", key).send(validBody());
+    expect(res.status).toBe(201);
+    expect(res.body.data.ticketNumber).toMatch(/^TKT-\d{6}$/);
+    expect(res.body.data.currentStatus).toBe("NEW");
+    expect(res.body.data.requesterId).toBe(requesterId);
+  });
+
+  it("replays the same key and rejects a changed payload", async () => {
+    const key = randomUUID();
+    const first = await request(app).post("/api/tickets").set("X-Requester-Id", String(requesterId)).set("Idempotency-Key", key).send(validBody({ summary: "Printer cannot connect" }));
+    const replay = await request(app).post("/api/tickets").set("X-Requester-Id", String(requesterId)).set("Idempotency-Key", key).send(validBody({ summary: "Printer cannot connect" }));
+    const conflict = await request(app).post("/api/tickets").set("X-Requester-Id", String(requesterId)).set("Idempotency-Key", key).send(validBody({ summary: "Different request" }));
+    expect(first.status).toBe(201);
+    expect(replay.status).toBe(200);
+    expect(replay.headers["idempotent-replay"]).toBe("true");
+    expect(replay.body.data.id).toBe(first.body.data.id);
+    expect(conflict.status).toBe(409);
+  });
+
+  it("returns field-level validation and never creates an invalid row", async () => {
+    const res = await request(app).post("/api/tickets").set("X-Requester-Id", String(requesterId)).set("Idempotency-Key", randomUUID()).send(validBody({ summary: "x", requestedPriority: "INVALID" }));
+    expect(res.status).toBe(400);
+    expect(res.body.fields).toMatchObject({ summary: expect.any(String), requestedPriority: expect.any(String) });
+  });
+});


### PR DESCRIPTION
## Summary
- implements `POST /api/tickets` with backend validation and active reference checks
- derives ownership from `X-Requester-Id`, generates the official Ticket Number, and defaults status to NEW
- adds requester-scoped idempotency replay/conflict handling with immutable canonical payload hashes
- adds responsive Create Ticket UI with reference-data loading, field errors, busy state, success, retry, and Create Another Ticket
- adds focused API and UI tests

## Verification
- server tests: 9/9 passed
- client tests: 10/10 passed
- server and client builds passed
- `git diff --check` passed
- no authentication, IT Staff workflow, or attachment persistence was introduced; attachments remain for Issue #22

Closes #19.